### PR TITLE
Dynamic RViz namespace handling and default C codegen directory

### DIFF
--- a/px4_mpc/px4_mpc/config/config.rviz
+++ b/px4_mpc/px4_mpc/config/config.rviz
@@ -66,7 +66,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_visualizer/vehicle_pose
+        Value: __NS__/px4_visualizer/vehicle_pose
       Value: true
     - Alpha: 1
       Buffer Length: 1
@@ -94,7 +94,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_visualizer/vehicle_path
+        Value: __NS__/px4_visualizer/vehicle_path
       Value: true
     - Alpha: 1
       Buffer Length: 1
@@ -122,14 +122,14 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_mpc/predicted_path
+        Value: __NS__/px4_mpc/predicted_path
       Value: true
     - Class: rviz_default_plugins/InteractiveMarkers
       Enable Transparency: true
       Enabled: true
-      Interactive Markers Namespace: /rviz_target_pose_marker
+      Interactive Markers Namespace: __NS__/rviz_target_pose_marker
       Name: InteractiveMarkers
-      Show Axes: false
+      Show Axes: true
       Show Descriptions: true
       Show Visual Aids: false
       Value: true
@@ -144,7 +144,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /px4_mpc/reference
+        Value: __NS__/px4_mpc/reference
       Value: true
   Enabled: true
   Global Options:

--- a/px4_mpc/px4_mpc/controllers/multirotor_rate_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/multirotor_rate_mpc.py
@@ -35,6 +35,7 @@ from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSimSolver
 import numpy as np
 import scipy.linalg
 import casadi as cs
+import os
 
 class MultirotorRateMPC():
     def __init__(self, model):
@@ -49,6 +50,14 @@ class MultirotorRateMPC():
     def setup(self, x0, N_horizon, Tf):
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
+
+        # Set directory for code generation and json file
+        this_file_dir = os.path.dirname(os.path.abspath(__file__))
+        package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
+        codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        json_path = os.path.join(codegen_dir, 'acados_ocp.json')
+        os.makedirs(codegen_dir, exist_ok=True)
+        ocp.code_export_directory = codegen_dir
 
         # set model
         model = self.model.get_acados_model()
@@ -117,11 +126,12 @@ class MultirotorRateMPC():
         # set prediction horizon
         ocp.solver_options.tf = Tf
 
-        ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
+        ocp_solver = AcadosOcpSolver(ocp, json_file=json_path)
         # create an integrator with the same settings as used in the OCP solver.
-        acados_integrator = AcadosSimSolver(ocp, json_file = 'acados_ocp.json')
+        acados_integrator = AcadosSimSolver(ocp, json_file=json_path)
 
         return ocp_solver, acados_integrator
+    
     def solve(self, x0, verbose=False):
 
         # preparation phase

--- a/px4_mpc/px4_mpc/controllers/spacecraft_direct_allocation_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_direct_allocation_mpc.py
@@ -33,9 +33,8 @@
 
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSimSolver
 import numpy as np
-import scipy.linalg
 import casadi as cs
-import time
+import os
 
 class SpacecraftDirectAllocationMPC():
     def __init__(self, model):
@@ -50,6 +49,13 @@ class SpacecraftDirectAllocationMPC():
     def setup(self, x0, N_horizon, Tf):
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
+        
+        # Set directory for code generation
+        this_file_dir = os.path.dirname(os.path.abspath(__file__))
+        package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
+        codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        os.makedirs(codegen_dir, exist_ok=True)
+        ocp.code_export_directory = codegen_dir
 
         # set model
         model = self.model.get_acados_model()

--- a/px4_mpc/px4_mpc/controllers/spacecraft_direct_allocation_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_direct_allocation_mpc.py
@@ -50,10 +50,11 @@ class SpacecraftDirectAllocationMPC():
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
         
-        # Set directory for code generation
+        # Set directory for code generation and json file
         this_file_dir = os.path.dirname(os.path.abspath(__file__))
         package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
         codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        json_path = os.path.join(codegen_dir, 'acados_ocp.json')
         os.makedirs(codegen_dir, exist_ok=True)
         ocp.code_export_directory = codegen_dir
 
@@ -136,9 +137,9 @@ class SpacecraftDirectAllocationMPC():
         # set prediction horizon
         ocp.solver_options.tf = Tf
 
-        ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
+        ocp_solver = AcadosOcpSolver(ocp, json_file=json_path)
         # create an integrator with the same settings as used in the OCP solver.
-        acados_integrator = AcadosSimSolver(ocp, json_file = 'acados_ocp.json')
+        acados_integrator = AcadosSimSolver(ocp, json_file=json_path)
 
         return ocp_solver, acados_integrator
 

--- a/px4_mpc/px4_mpc/controllers/spacecraft_rate_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_rate_mpc.py
@@ -33,8 +33,8 @@
 
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSimSolver
 import numpy as np
-import scipy.linalg
 import casadi as cs
+import os
 
 class SpacecraftRateMPC():
     def __init__(self, model):
@@ -50,6 +50,13 @@ class SpacecraftRateMPC():
     def setup(self, x0, N_horizon, Tf):
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
+
+        # Set directory for code generation
+        this_file_dir = os.path.dirname(os.path.abspath(__file__))
+        package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
+        codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        os.makedirs(codegen_dir, exist_ok=True)
+        ocp.code_export_directory = codegen_dir
 
         # set model
         model = self.model.get_acados_model()

--- a/px4_mpc/px4_mpc/controllers/spacecraft_rate_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_rate_mpc.py
@@ -51,10 +51,11 @@ class SpacecraftRateMPC():
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
 
-        # Set directory for code generation
+        # Set directory for code generation and json file
         this_file_dir = os.path.dirname(os.path.abspath(__file__))
         package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
         codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        json_path = os.path.join(codegen_dir, 'acados_ocp.json')
         os.makedirs(codegen_dir, exist_ok=True)
         ocp.code_export_directory = codegen_dir
 
@@ -134,9 +135,9 @@ class SpacecraftRateMPC():
         # set prediction horizon
         ocp.solver_options.tf = Tf
 
-        ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
+        ocp_solver = AcadosOcpSolver(ocp, json_file=json_path)
         # create an integrator with the same settings as used in the OCP solver.
-        acados_integrator = AcadosSimSolver(ocp, json_file = 'acados_ocp.json')
+        acados_integrator = AcadosSimSolver(ocp, json_file=json_path)
 
         return ocp_solver, acados_integrator
 

--- a/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
@@ -50,10 +50,11 @@ class SpacecraftWrenchMPC():
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
 
-        # Set directory for code generation
+        # Set directory for code generation and json file
         this_file_dir = os.path.dirname(os.path.abspath(__file__))
         package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
         codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        json_path = os.path.join(codegen_dir, 'acados_ocp.json')
         os.makedirs(codegen_dir, exist_ok=True)
         ocp.code_export_directory = codegen_dir
 
@@ -135,9 +136,9 @@ class SpacecraftWrenchMPC():
         # set prediction horizon
         ocp.solver_options.tf = Tf
 
-        ocp_solver = AcadosOcpSolver(ocp, json_file = 'acados_ocp.json')
+        ocp_solver = AcadosOcpSolver(ocp, json_file=json_path)
         # create an integrator with the same settings as used in the OCP solver.
-        acados_integrator = AcadosSimSolver(ocp, json_file = 'acados_ocp.json')
+        acados_integrator = AcadosSimSolver(ocp, json_file=json_path)
 
         return ocp_solver, acados_integrator
 

--- a/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
+++ b/px4_mpc/px4_mpc/controllers/spacecraft_wrench_mpc.py
@@ -33,8 +33,8 @@
 
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSimSolver
 import numpy as np
-import scipy.linalg
 import casadi as cs
+import os
 
 class SpacecraftWrenchMPC():
     def __init__(self, model):
@@ -49,6 +49,13 @@ class SpacecraftWrenchMPC():
     def setup(self, x0, N_horizon, Tf):
         # create ocp object to formulate the OCP
         ocp = AcadosOcp()
+
+        # Set directory for code generation
+        this_file_dir = os.path.dirname(os.path.abspath(__file__))
+        package_root = os.path.abspath(os.path.join(this_file_dir, '..'))
+        codegen_dir = os.path.join(package_root, 'mpc_codegen')
+        os.makedirs(codegen_dir, exist_ok=True)
+        ocp.code_export_directory = codegen_dir
 
         # set model
         model = self.model.get_acados_model()

--- a/px4_mpc/px4_mpc/launch/mpc_quadrotor_launch.py
+++ b/px4_mpc/px4_mpc/launch/mpc_quadrotor_launch.py
@@ -36,28 +36,55 @@ __author__ = "Jaeyoung Lim"
 __contact__ = "jalim@ethz.ch"
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch.conditions import IfCondition, UnlessCondition
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
+import tempfile
 
 
 def generate_launch_description():
+    namespace_arg = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Namespace for all nodes'
+    )
+
+    setpoint_from_rviz_arg = DeclareLaunchArgument(
+        'setpoint_from_rviz',
+        default_value='true',
+        description='Publish setpoint pose via rviz'
+    )
+
+    namespace = LaunchConfiguration('namespace')
+    setpoint_from_rviz = LaunchConfiguration('setpoint_from_rviz')
+
     return LaunchDescription([
+        namespace_arg,
+        setpoint_from_rviz_arg,
         Node(
             package='px4_mpc',
-            namespace='px4_mpc',
+            namespace=namespace,
             executable='mpc_quadrotor',
             name='mpc_quadrotor',
             output='screen',
             emulate_tty=True,
+            parameters=[
+                {'namespace': namespace},
+                {'setpoint_from_rviz': setpoint_from_rviz}
+            ]
         ),
         Node(
             package='px4_mpc',
-            namespace='px4_mpc',
+            namespace=namespace,
             executable='rviz_pos_marker',
             name='rviz_pos_marker',
             output='screen',
             emulate_tty=True,
+            parameters=[{'namespace': namespace}],
+            condition=IfCondition(setpoint_from_rviz)
         ),
         # Node(
         #     package='micro_ros_agent',
@@ -67,15 +94,48 @@ def generate_launch_description():
         #     output='screen'),
         Node(
             package='px4_offboard',
-            namespace='px4_offboard',
+            namespace=namespace,
             executable='visualizer',
-            name='visualizer'
+            name='visualizer',
+            parameters=[{'namespace': namespace}],
+            condition=IfCondition(setpoint_from_rviz)
         ),
+        OpaqueFunction(function=launch_setup),
+    ])
+
+def patch_rviz_config(original_config_path, namespace):
+    """
+    Patch the RViz configuration file to replace the namespace placeholder with the actual namespace.
+    """
+    with open(original_config_path, 'r') as f:
+        content = f.read()
+
+    # Replace placeholder with actual namespace
+    content = content.replace('__NS__', f'/{namespace}' if namespace else '')
+    
+    # Write to temporary file
+    tmp_rviz_config = tempfile.NamedTemporaryFile(delete=False, suffix='.rviz')
+    tmp_rviz_config.write(content.encode('utf-8'))
+    tmp_rviz_config.close()
+
+    return tmp_rviz_config.name
+
+
+def launch_setup(context, *args, **kwargs):
+    """
+    Function to set up the launch context and patch the RViz configuration.
+    """
+    namespace = LaunchConfiguration('namespace').perform(context)
+    rviz_config_path = os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')
+    patched_config = patch_rviz_config(rviz_config_path, namespace)
+
+    return [
         Node(
             package='rviz2',
             namespace='',
             executable='rviz2',
             name='rviz2',
-            arguments=['-d', [os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')]]
+            arguments=['-d', patched_config],
+            condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
         )
-    ])
+    ]

--- a/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
+++ b/px4_mpc/px4_mpc/launch/mpc_spacecraft_launch.py
@@ -36,16 +36,16 @@ __author__ = "Pedro Roque, Jaeyoung Lim"
 __contact__ = "padr@kth.se, jalim@ethz.ch"
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch.conditions import IfCondition, UnlessCondition
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 import os
+import tempfile
 
 
 def generate_launch_description():
-    # Declare launch arguments
     mode_arg = DeclareLaunchArgument(
         'mode',
         default_value='direct_allocation',
@@ -54,7 +54,7 @@ def generate_launch_description():
 
     namespace_arg = DeclareLaunchArgument(
         'namespace',
-        default_value='',  # Default namespace is empty
+        default_value='',
         description='Namespace for all nodes'
     )
 
@@ -92,10 +92,8 @@ def generate_launch_description():
             name='rviz_pos_marker',
             output='screen',
             emulate_tty=True,
-            parameters=[
-                {'namespace': namespace}
-            ],
-            condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
+            parameters=[{'namespace': namespace}],
+            condition=IfCondition(setpoint_from_rviz)
         ),
         Node(
             package='px4_mpc',
@@ -104,27 +102,53 @@ def generate_launch_description():
             name='test_setpoints',
             output='screen',
             emulate_tty=True,
-            parameters=[
-                {'namespace': namespace}
-            ],
-            condition=UnlessCondition(LaunchConfiguration('setpoint_from_rviz'))
+            parameters=[{'namespace': namespace}],
+            condition=UnlessCondition(setpoint_from_rviz)
         ),
         Node(
             package='px4_offboard',
             namespace=namespace,
             executable='visualizer',
             name='visualizer',
-            parameters=[
-                {'namespace': namespace}
-            ],
-            condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
+            parameters=[{'namespace': namespace}],
+            condition=IfCondition(setpoint_from_rviz)
         ),
+        OpaqueFunction(function=launch_setup),
+    ])
+
+def patch_rviz_config(original_config_path, namespace):
+    """
+    Patch the RViz configuration file to replace the namespace placeholder with the actual namespace.
+    """
+    with open(original_config_path, 'r') as f:
+        content = f.read()
+
+    # Replace placeholder with actual namespace
+    content = content.replace('__NS__', f'/{namespace}' if namespace else '')
+    
+    # Write to temporary file
+    tmp_rviz_config = tempfile.NamedTemporaryFile(delete=False, suffix='.rviz')
+    tmp_rviz_config.write(content.encode('utf-8'))
+    tmp_rviz_config.close()
+
+    return tmp_rviz_config.name
+
+
+def launch_setup(context, *args, **kwargs):
+    """
+    Function to set up the launch context and patch the RViz configuration.
+    """
+    namespace = LaunchConfiguration('namespace').perform(context)
+    rviz_config_path = os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')
+    patched_config = patch_rviz_config(rviz_config_path, namespace)
+
+    return [
         Node(
             package='rviz2',
             namespace='',
             executable='rviz2',
             name='rviz2',
-            arguments=['-d', os.path.join(get_package_share_directory('px4_mpc'), 'config.rviz')],
+            arguments=['-d', patched_config],
             condition=IfCondition(LaunchConfiguration('setpoint_from_rviz'))
-        ),
-    ])
+        )
+    ]

--- a/px4_mpc/px4_mpc/rviz_pos_marker.py
+++ b/px4_mpc/px4_mpc/rviz_pos_marker.py
@@ -192,7 +192,7 @@ class ProcessFeedback():
         # self.menu_handler.insert('Reset Position', parent=sub_menu_handle, callback=process_feedback.processFeedback)
         # self.menu_handler.insert('Reset Orientation', parent=sub_menu_handle, callback=process_feedback.processFeedback)
 
-        position = Point(x=0.0, y=3.0, z=3.0)
+        position = Point(x=1.0, y=1.0, z=0.0)
         make6DofMarker(self.server, self.menu_handler, self.processFeedback, True, InteractiveMarkerControl.NONE, position, True)
         self.server.applyChanges()
 

--- a/px4_mpc/setup.py
+++ b/px4_mpc/setup.py
@@ -22,7 +22,6 @@ setup(
     maintainer_email='jalim@ethz.ch',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
                 'mpc_quadrotor = px4_mpc.mpc_quadrotor:main',


### PR DESCRIPTION
This PR updates the launch file to support dynamic namespacing in the RViz configuration and sets a default directory for Acados' generated C code.

* Replaces hardcoded topic names in the `.rviz` file with a `__NS__` placeholder.
* Adds logic to patch the config at launch time based on the `namespace` argument.
* Supports both namespaced and non-namespaced launches.
* Generated C code and JSON are placed in the default directory `mpc_codegen`.